### PR TITLE
Consider only apply-jobs with delta files

### DIFF
--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -2,6 +2,7 @@ import logging
 from datetime import timedelta
 
 from constance import config
+from django.db import models
 from django.utils import timezone
 from django_cron import CronJobBase, Schedule
 from invitations.utils import get_invitation_model
@@ -114,7 +115,12 @@ class RescheduleFailedApplyJobs(CronJobBase):
 
     def do(self):
         # Find every failed apply job and create a new one with the deltas that failed
-        failed_apply_jobs = ApplyJob.objects.filter(status=ApplyJob.Status.FAILED)
+
+        failed_apply_jobs = (
+            ApplyJob.objects.filter(status=ApplyJob.Status.FAILED)
+            .annotate(delta_count=models.Count("applyjobdelta"))
+            .filter(delta_count__gt=0)
+        )
         for job in failed_apply_jobs:
             new_apply_job = ApplyJob.objects.create(
                 project=job.project,

--- a/docker-app/qfieldcloud/core/tests/test_cron.py
+++ b/docker-app/qfieldcloud/core/tests/test_cron.py
@@ -113,6 +113,19 @@ class RescheduleFailedApplyJobsTestCase(TestCase):
         self.assertEqual(d1.last_status, Delta.Status.APPLIED)
         self.assertEqual(d4.last_status, Delta.Status.APPLIED)
 
+    def test_failed_jobs_without_deltas_are_not_considered(self):
+        ApplyJob.objects.create(
+            project=self.project1,
+            created_by=self.user,
+            overwrite_conflicts=True,
+            status=ApplyJob.Status.FAILED,
+        )
+
+        RescheduleFailedApplyJobs().do()
+
+        # No new apply jobs should be created
+        self.assertEqual(ApplyJob.objects.count(), 1)
+
     def test_multiple_failed_apply_jobs(self):
         # First failed job
         aj1 = ApplyJob.objects.create(


### PR DESCRIPTION
Previously  new ApplyJobs without any deltas were created for every failed ApplyJob.